### PR TITLE
refactor how repo-level vendor directory is handled

### DIFF
--- a/components/composer
+++ b/components/composer
@@ -57,9 +57,10 @@ fi
 REPOSITORY_ROOT=$(\
   command git rev-parse --show-toplevel 2> /dev/null || \
   command hg root 2> /dev/null)
-VENDOR_MOUNT=""
-if [ -d "${REPOSITORY_ROOT}" ]; then
-  VENDOR_MOUNT="--volume ${REPOSITORY_ROOT}/vendor:/vendor:z"
+ROOT_VENDOR_DIR="${REPOSITORY_ROOT}/vendor"
+CURRENT_DIR="${PWD}"
+if [ -d "${ROOT_VENDOR_DIR}" ] && [ "${CURRENT_DIR}" != "${REPOSITORY_ROOT}" ]; then
+    pushd "${REPOSITORY_ROOT}" &> /dev/null
 fi
 
 
@@ -69,8 +70,12 @@ docker run \
     --interactive \
     --user $(id -u):$(id -g) \
     $COMPOSER_MOUNT \
-    $VENDOR_MOUNT \
     --volume /etc/passwd:/etc/passwd:ro \
     --volume /etc/group:/etc/group:ro \
     --volume $(pwd):/app \
     composer "$@"
+
+
+if [ -d "${ROOT_VENDOR_DIR}" ] && [ "${CURRENT_DIR}" != "${REPOSITORY_ROOT}" ]; then
+    popd &> /dev/null
+fi


### PR DESCRIPTION
Mounting the repo-level vendor directory inside the image (either
at the global location, or by overriding /app/vendor [where `app`
is really the current directory on the host]) introduces several
problems, namely, that post-install hooks will not be executed at the
root level, but rather in the current host directory. Additionally, the
composer.json and composer.lock files in the repository root will not be
used.

This changeset refactors what happens when a vendor directory is found
in the repository's root. If we find a vendor directory in the
repository's root, we assume that we are inside of a monolithic
repository, and that the repo-root really where `composer` should be
executed -- so we switch into it, and out back to our previous directory
when the command has completed execution.

closes gh-12